### PR TITLE
Separate mod menu popup creation for patching

### DIFF
--- a/Main/UI/ModsUI.cs
+++ b/Main/UI/ModsUI.cs
@@ -44,11 +44,11 @@ namespace Silk
             // Create mods menu
             foreach (var mod in modList)
             {
-                ModsMenu.instance.CreateButton(mod.title, () => { ModsMenuPopup ui = MakeAnnouncer(mod); });
+                ModsMenu.instance.CreateButton(mod.title, () => { ModsMenuPopup ui = MakePopup(mod); });
             }
         }
 
-        private static ModsMenuPopup MakeAnnouncer((string title, string[] authors, string version, string gameVersion, string id) mod)
+        private static ModsMenuPopup MakePopup((string title, string[] authors, string version, string gameVersion, string id) mod)
         {
             Logger.LogInfo("testing");
             var ui = Announcer.ModsPopup(mod.title);

--- a/Main/UI/ModsUI.cs
+++ b/Main/UI/ModsUI.cs
@@ -57,6 +57,7 @@ namespace Silk
             ui.CreateParagraph($"Version: {mod.version}");
             ui.CreateParagraph($"Designed for SpiderHeck version: {mod.gameVersion}");
             ui.CreateParagraph($"ID: {mod.id}");
+            ui.CreateDivider();
             return ui;
         }
     }

--- a/Main/UI/ModsUI.cs
+++ b/Main/UI/ModsUI.cs
@@ -44,15 +44,20 @@ namespace Silk
             // Create mods menu
             foreach (var mod in modList)
             {
-                ModsMenu.instance.CreateButton(mod.title, () => {
-                    var ui = Announcer.ModsPopup(mod.title);
-                    ui.CreateDivider();
-                    ui.CreateParagraph($"Authors: {string.Join(", ", mod.authors)}");
-                    ui.CreateParagraph($"Version: {mod.version}");
-                    ui.CreateParagraph($"Designed for SpiderHeck version: {mod.gameVersion}");
-                    ui.CreateParagraph($"ID: {mod.id}");
-                });
+                ModsMenu.instance.CreateButton(mod.title, () => { ModsMenuPopup ui = MakeAnnouncer(mod); });
             }
+        }
+
+        private static ModsMenuPopup MakeAnnouncer((string title, string[] authors, string version, string gameVersion, string id) mod)
+        {
+            Logger.LogInfo("testing");
+            var ui = Announcer.ModsPopup(mod.title);
+            ui.CreateDivider();
+            ui.CreateParagraph($"Authors: {string.Join(", ", mod.authors)}");
+            ui.CreateParagraph($"Version: {mod.version}");
+            ui.CreateParagraph($"Designed for SpiderHeck version: {mod.gameVersion}");
+            ui.CreateParagraph($"ID: {mod.id}");
+            return ui;
         }
     }
 }


### PR DESCRIPTION
This separates out the creation of a ModsMenuPopup into a different method, allowing mods to patch it so they can display custom content and settings in their menu underneath the default content.

Example that I threw into the bottom of my InfiniteAmmo mod for testing:
```
[HarmonyPatch(typeof(Silk.ModsUI), nameof(ModsUI.MakePopup))]
internal class ModsMenuPatch
{
    public static void Postfix((string title, string[] authors, string version, string gameVersion, string id) mod, ref ModsMenuPopup __result)
    {
        if (mod.title != "InfiniteAmmo") return;
        __result.CreateParagraph("testing123");
    }
}
```

![image](https://github.com/user-attachments/assets/b545be3f-4858-4cda-9961-11622e585173)

